### PR TITLE
20260529_smallbugfix

### DIFF
--- a/bin/htmettxt.f
+++ b/bin/htmettxt.f
@@ -137,6 +137,11 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc 
 c Calculation
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      if(c0idx.eq.'MY'.or.c0idx.eq.'MM'.or.c0idx.eq.'MD')then
+         i0yearminout=n0yearmin-1
+         i0yearmaxout=n0yearmin-1
+      end if
+      
       do i0year=i0yearminout,i0yearmaxout
         r0maxsim=p0maxini
         r0maxobs=p0maxini

--- a/met/pre/prep_WFDEI.sh
+++ b/met/pre/prep_WFDEI.sh
@@ -92,7 +92,7 @@ for VAR in $VARS; do
    NC=../../met/org/WFDEI/3hourly/${VAR2}_${ADD}_${YEAR}${MON}.nc
       elif [ $TRESO = DY ]; then
 #  NC=../../met/org/WFDEI/daily/${VAR}_daily_${ADD}_${YEAR}${MON}.nc(outdated)
-   NC=../../met/org/WFDEI/daily/${VAR2}_wfde_____${YEAR}${MON}_DY.nc
+   NC=../../met/org/WFDEI/daily/${VAR}_wfde_____${YEAR}${MON}_DY.nc
       fi
       echo $NC
 #


### PR DESCRIPTION
In this branch, line 95 in met/pre/prep_WFDEI.sh and bin/ has been fixed to work correctly.
Additionally, code was added to fix an issue where meteorological data was output upside down (north–south flipped), in lines 140–144 of bin/htmettxt.f.
